### PR TITLE
[#18] 감정 통계 화면에서 감정별 분석을 눌렀을때 나오는 지출 카드 UI 겹침 현상 수정

### DIFF
--- a/lib/features/expense/screens/emotion_detail_screen.dart
+++ b/lib/features/expense/screens/emotion_detail_screen.dart
@@ -78,8 +78,10 @@ class EmotionDetailScreen extends ConsumerWidget {
                   itemCount: filteredExpenses.length,
                   itemBuilder: (context, index) {
                     return Padding(
-                        padding: const EdgeInsets.only(bottom: 12),
-                        child: ExpenseCardWidget(expense: filteredExpenses[index])
+                      padding: const EdgeInsets.only(bottom: 12),
+                      child: ExpenseCardWidget(
+                        expense: filteredExpenses[index],
+                      ),
                     );
                   },
                 ),


### PR DESCRIPTION
감정별 분석 화면에서 지출 카드 UI 겹침을 수정하였다.

This closes #18 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 비용 목록의 항목 간 수직 간격이 개선되었습니다. 각 항목에 12픽셀의 하단 여백이 추가되어 더 나은 시각적 구분을 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->