### PR TITLE
fix: flutter build ios 제거로 누락된 pod install 추가

### DIFF
--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -30,6 +30,9 @@ jobs:
       - name: 빌드러너 실행
         run: flutter pub run build_runner build --delete-conflicting-outputs
 
+      - name: CocoaPods 설치
+        run: cd ios && pod install
+
       # Fastlane (Xcode 빌드 & 서명 & 업로드 담당)
       - name: Ruby 설정
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
flutter build ios가 자동으로 pod install을 실행했는데,
해당 단계 제거 후 CocoaPods 의존성이 설치되지 않아
xcfilelist 로드 실패로 빌드가 깨졌음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * iOS 빌드 자동화 워크플로우가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->