### PR TITLE
fix: code_sign_identity를 Apple Distribution으로 명시

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -31,6 +31,7 @@ platform :ios do
       team_id: ENV["DEVELOPMENT_TEAM_ID"],
       bundle_identifier: "com.gunhee.expensediary",
       profile_name: ENV["PROVISIONING_PROFILE_NAME"],
+      code_sign_identity: "Apple Distribution",
     )
 
     # Xcode 빌드 & 아카이브 (Flutter 빌드는 워크플로우에서 완료)


### PR DESCRIPTION
update_code_signing_settings가 Debug 포함 전체 설정에 적용되면서 iOS Development 인증서를 찾으려 했으나 Distribution 인증서만 존재. code_sign_identity를 명시하여 올바른 인증서를 사용하도록 수정.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * iOS 빌드 구성이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->