### PR TITLE
fix: CI에 FlutterFire CLI 설치 추가

### DIFF
--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -23,6 +23,9 @@ jobs:
       - name: 의존성 설치
         run: flutter pub get
 
+      - name: FlutterFire CLI 설치
+        run: dart pub global activate flutterfire_cli
+
       - name: GoogleService-Info.plist 복원
         run: |
           echo "${{ secrets.IOS_GOOGLE_SERVICE_INFO_PLIST }}" | base64 --decode > ios/Runner/GoogleService-Info.plist


### PR DESCRIPTION
Xcode 빌드 페이즈의 flutterfire upload-crashlytics-symbols 스크립트가 CI에서 flutterfire CLI를 찾지 못해 빌드 실패.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * iOS 배포 워크플로우 프로세스 개선으로 빌드 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->