### PR TITLE
feat : 지출 리스트 화면에서 날짜 필터를 설정할 수 있도록 설정

### DIFF
--- a/lib/core/database/daos/expense_dao.dart
+++ b/lib/core/database/daos/expense_dao.dart
@@ -74,4 +74,44 @@ class ExpenseDao extends DatabaseAccessor<AppDatabase> with _$ExpenseDaoMixin {
           ..orderBy([(t) => OrderingTerm.desc(t.date)]))
         .get();
   }
+
+  /// 필터링된 지출 조회 (Stream)
+  ///
+  /// [emotion] 감정 필터 (null이면 모든 감정)
+  /// [startDate] 시작 날짜
+  /// [endDate] 종료 날짜 (해당 날짜의 23:59:59까지 포함)
+  Stream<List<ExpenseEntityData>> watchExpenses({
+    String? emotion,
+    required DateTime startDate,
+    required DateTime endDate,
+  }) {
+    final query = select(expenseEntity);
+
+    // endDate의 하루 전체를 포함하도록 23:59:59로 조정
+    final inclusiveEndDate = DateTime(
+      endDate.year,
+      endDate.month,
+      endDate.day,
+      23,
+      59,
+      59,
+    );
+
+    // 날짜 필터 (필수)
+    query.where(
+      (t) =>
+          t.date.isBiggerOrEqualValue(startDate) &
+          t.date.isSmallerOrEqualValue(inclusiveEndDate),
+    );
+
+    // 감정 필터 (선택)
+    if (emotion != null) {
+      query.where((t) => t.emotion.equals(emotion));
+    }
+
+    // 최신순 정렬
+    query.orderBy([(t) => OrderingTerm.desc(t.date)]);
+
+    return query.watch();
+  }
 }

--- a/lib/core/database/daos/expense_dao.dart
+++ b/lib/core/database/daos/expense_dao.dart
@@ -87,21 +87,18 @@ class ExpenseDao extends DatabaseAccessor<AppDatabase> with _$ExpenseDaoMixin {
   }) {
     final query = select(expenseEntity);
 
-    // endDate의 하루 전체를 포함하도록 23:59:59로 조정
+    // endDate의 하루 전체를 포함하도록 다음날까지 설정
     final inclusiveEndDate = DateTime(
       endDate.year,
       endDate.month,
-      endDate.day,
-      23,
-      59,
-      59,
+      endDate.day + 1,
     );
 
     // 날짜 필터 (필수)
     query.where(
       (t) =>
           t.date.isBiggerOrEqualValue(startDate) &
-          t.date.isSmallerOrEqualValue(inclusiveEndDate),
+          t.date.isSmallerThanValue(inclusiveEndDate),
     );
 
     // 감정 필터 (선택)

--- a/lib/features/expense/models/expense_filter.dart
+++ b/lib/features/expense/models/expense_filter.dart
@@ -1,0 +1,68 @@
+import 'package:expense_tracker/features/expense/models/expense.dart';
+
+/// 지출 필터 조건
+class ExpenseFilter {
+  /// 필터 생성자
+  const ExpenseFilter({
+    this.emotion,
+    required this.startDate,
+    required this.endDate,
+  });
+
+  /// 이번 달 필터 생성
+  factory ExpenseFilter.thisMonth({ExpenseEmotions? emotion}) {
+    final now = DateTime.now();
+    return ExpenseFilter(
+      emotion: emotion,
+      startDate: DateTime(now.year, now.month),
+      endDate: DateTime(now.year, now.month + 1, 0),
+    );
+  }
+
+  /// 특정 달 필터 생성
+  factory ExpenseFilter.month(
+    int year,
+    int month, {
+    ExpenseEmotions? emotion,
+  }) {
+    return ExpenseFilter(
+      emotion: emotion,
+      startDate: DateTime(year, month),
+      endDate: DateTime(year, month + 1, 0),
+    );
+  }
+
+  /// 감정 필터 (null이면 전체)
+  final ExpenseEmotions? emotion;
+
+  /// 시작 날짜
+  final DateTime startDate;
+
+  /// 종료 날짜
+  final DateTime endDate;
+
+  /// 필터 복사
+  ExpenseFilter copyWith({
+    ExpenseEmotions? emotion,
+    DateTime? startDate,
+    DateTime? endDate,
+    bool clearEmotion = false,
+  }) {
+    return ExpenseFilter(
+      emotion: clearEmotion ? null : (emotion ?? this.emotion),
+      startDate: startDate ?? this.startDate,
+      endDate: endDate ?? this.endDate,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is ExpenseFilter &&
+        other.emotion == emotion &&
+        other.startDate == startDate &&
+        other.endDate == endDate;
+  }
+
+  @override
+  int get hashCode => Object.hash(emotion, startDate, endDate);
+}

--- a/lib/features/expense/providers/expense_list_stream_provider.dart
+++ b/lib/features/expense/providers/expense_list_stream_provider.dart
@@ -1,0 +1,20 @@
+import 'package:expense_tracker/features/expense/models/expense.dart';
+import 'package:expense_tracker/features/expense/models/expense_filter.dart';
+import 'package:expense_tracker/features/expense/repositories/expense_repository.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
+
+/// 필터링된 지출 목록 Stream Provider
+///
+/// 이 Provider는:
+/// 1. ExpenseFilter를 파라미터로 받아 필터링
+/// 2. DB에서 필터링된 데이터만 가져옴
+/// 3. DB 변경 시 자동으로 갱신 (Drift의 watch 기능)
+final StreamProviderFamily<List<Expense>, ExpenseFilter> expenseListStreamProvider = StreamProvider.autoDispose
+    .family<List<Expense>, ExpenseFilter>((ref, filter) {
+      final repository = ref.read(expenseRepositoryProvider);
+
+      return repository.watchExpenses(
+        expenseFilter: filter,
+      );
+    });

--- a/lib/features/expense/providers/expense_list_stream_provider.dart
+++ b/lib/features/expense/providers/expense_list_stream_provider.dart
@@ -10,7 +10,8 @@ import 'package:flutter_riverpod/misc.dart';
 /// 1. ExpenseFilter를 파라미터로 받아 필터링
 /// 2. DB에서 필터링된 데이터만 가져옴
 /// 3. DB 변경 시 자동으로 갱신 (Drift의 watch 기능)
-final StreamProviderFamily<List<Expense>, ExpenseFilter> expenseListStreamProvider = StreamProvider.autoDispose
+final StreamProviderFamily<List<Expense>, ExpenseFilter>
+expenseListStreamProvider = StreamProvider.autoDispose
     .family<List<Expense>, ExpenseFilter>((ref, filter) {
       final repository = ref.read(expenseRepositoryProvider);
 

--- a/lib/features/expense/repositories/expense_repository.dart
+++ b/lib/features/expense/repositories/expense_repository.dart
@@ -2,6 +2,7 @@ import 'package:drift/drift.dart' show Value;
 import 'package:expense_tracker/core/database/app_database.dart';
 import 'package:expense_tracker/core/database/daos/expense_dao.dart';
 import 'package:expense_tracker/features/expense/models/expense.dart';
+import 'package:expense_tracker/features/expense/models/expense_filter.dart';
 import 'package:expense_tracker/features/expense/models/expense_form.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -71,6 +72,22 @@ class ExpenseRepository {
   Future<List<Expense>> filterByStatus(ExpenseEmotions emotion) async {
     final rows = await _dao.filterByStatus(emotion.name);
     return rows.map(_expenseEntityToExpense).toList();
+  }
+
+  /// 필터링된 지출 목록 Stream
+  ///
+  /// DB 변경 시 자동으로 갱신되는 Stream을 반환합니다.
+  /// [expenseFilter] 필터 조건 (감정, 날짜 범위)
+  Stream<List<Expense>> watchExpenses({
+    required ExpenseFilter expenseFilter,
+  }) {
+    return _dao
+        .watchExpenses(
+          emotion: expenseFilter.emotion?.name,
+          startDate: expenseFilter.startDate,
+          endDate: expenseFilter.endDate,
+        )
+        .map((entities) => entities.map(_expenseEntityToExpense).toList());
   }
 
   // 아래부터는 Drift DB 매핑용 헬퍼 메서드들

--- a/lib/features/expense/screens/add_expense_screen.dart
+++ b/lib/features/expense/screens/add_expense_screen.dart
@@ -318,7 +318,9 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
                       ),
                       decoration: InputDecoration(
                         hintText: '예) 친구와 커피',
-                        hintStyle: TextStyle(color: context.colors.textSecondary),
+                        hintStyle: TextStyle(
+                          color: context.colors.textSecondary,
+                        ),
                         filled: true,
                         fillColor: context.colors.surface,
                         border: OutlineInputBorder(
@@ -425,7 +427,9 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
                         ),
                         decoration: InputDecoration(
                           hintText: '왜 생각이 바뀌었나요?',
-                          hintStyle: TextStyle(color: context.colors.textSecondary),
+                          hintStyle: TextStyle(
+                            color: context.colors.textSecondary,
+                          ),
                           filled: true,
                           fillColor: const Color(0xFFFFF9E6),
                           border: OutlineInputBorder(
@@ -475,7 +479,9 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
                       ),
                       decoration: InputDecoration(
                         hintText: '메모 추가...',
-                        hintStyle: TextStyle(color: context.colors.textSecondary),
+                        hintStyle: TextStyle(
+                          color: context.colors.textSecondary,
+                        ),
                         filled: true,
                         fillColor: context.colors.surface,
                         border: OutlineInputBorder(

--- a/lib/features/expense/screens/add_expense_screen.dart
+++ b/lib/features/expense/screens/add_expense_screen.dart
@@ -1,9 +1,9 @@
 import 'package:expense_tracker/core/utils/layout_utils.dart';
 import 'package:expense_tracker/core/widgets/picker/date_picker_widget.dart';
 import 'package:expense_tracker/core/widgets/picker/time_spinner_widget.dart';
-import 'package:expense_tracker/features/expense/controllers/expense_controller.dart';
 import 'package:expense_tracker/features/expense/models/expense.dart';
 import 'package:expense_tracker/features/expense/models/expense_form.dart';
+import 'package:expense_tracker/features/expense/repositories/expense_repository.dart';
 import 'package:expense_tracker/features/expense/widgets/expense_form/amount_input_field.dart';
 import 'package:expense_tracker/features/expense/widgets/expense_form/category_selector_widget.dart';
 import 'package:expense_tracker/features/expense/widgets/expense_form/date_time_selector_widget.dart';
@@ -118,7 +118,7 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
     super.dispose();
   }
 
-  void _saveExpense() {
+  Future<void> _saveExpense() async {
     if (_titleController.text.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('지출 이름을 입력해주세요')),
@@ -149,6 +149,7 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
         int.tryParse(_amountController.text.replaceAll(',', '')) ?? 0;
 
     final formMode = widget.mode;
+    final repository = ref.read(expenseRepositoryProvider);
 
     if (formMode is Edit) {
       final changedExpense = formMode.originalExpense.copyWith(
@@ -165,9 +166,7 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
             ? _emotionChangeReasonController.text.trim()
             : formMode.originalExpense.emotionChangeReason,
       );
-      ref
-          .read(expenseControllerProvider.notifier)
-          .updateExpense(changedExpense);
+      await repository.updateExpense(changedExpense);
     } else {
       final expenseForm = ExpenseForm(
         title: _titleController.text,
@@ -177,9 +176,12 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
         date: _selectedDate,
         memo: _memoController.text.isEmpty ? null : _memoController.text,
       );
-      ref.read(expenseControllerProvider.notifier).addExpense(expenseForm);
+      await repository.addExpense(expenseForm);
     }
-    Navigator.pop(context);
+
+    if (mounted) {
+      Navigator.pop(context);
+    }
   }
 
   void _showDeleteDialog(BuildContext context, WidgetRef ref, int expenseId) {
@@ -211,52 +213,22 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
               onPressed: () {
                 Navigator.of(dialogContext).pop();
               },
-              style: TextButton.styleFrom(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 20,
-                  vertical: 12,
-                ),
-              ),
-              child: const Text(
-                '취소',
-                style: TextStyle(
-                  color: Color(0xFF999999),
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
+              child: const Text('취소'),
             ),
-            ElevatedButton(
-              onPressed: () {
-                ref
-                    .read(expenseControllerProvider.notifier)
-                    .deleteExpense(expenseId);
-                Navigator.of(dialogContext).pop(); // 다이얼로그 닫기
-                Navigator.of(context).pop(); // 수정 화면 닫기
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(
-                    content: Text('삭제되었습니다'),
-                    backgroundColor: Color(0xFF4CAF50),
-                  ),
-                );
+            TextButton(
+              onPressed: () async {
+                final repository = ref.read(expenseRepositoryProvider);
+                await repository.deleteExpense(expenseId);
+                if (dialogContext.mounted) {
+                  Navigator.of(dialogContext).pop();
+                }
+                if (context.mounted) {
+                  Navigator.of(context).pop();
+                }
               },
-              style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFF4CAF50),
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 20,
-                  vertical: 12,
-                ),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(8),
-                ),
-              ),
               child: const Text(
                 '삭제',
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: 16,
-                  fontWeight: FontWeight.bold,
-                ),
+                style: TextStyle(color: Colors.red),
               ),
             ),
           ],

--- a/lib/features/expense/screens/add_expense_screen.dart
+++ b/lib/features/expense/screens/add_expense_screen.dart
@@ -1,3 +1,4 @@
+import 'package:expense_tracker/core/themes/app_colors.dart';
 import 'package:expense_tracker/core/utils/layout_utils.dart';
 import 'package:expense_tracker/core/widgets/picker/date_picker_widget.dart';
 import 'package:expense_tracker/core/widgets/picker/time_spinner_widget.dart';
@@ -190,19 +191,19 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
       builder: (BuildContext dialogContext) {
         return AlertDialog(
           backgroundColor: Colors.white,
-          title: const Text(
+          title: Text(
             '삭제 확인',
             style: TextStyle(
               fontSize: 18,
               fontWeight: FontWeight.bold,
-              color: Colors.black,
+              color: context.colors.textPrimary,
             ),
           ),
-          content: const Text(
+          content: Text(
             '삭제 하시겠습니까?',
             style: TextStyle(
               fontSize: 16,
-              color: Color(0xFF666666),
+              color: context.colors.textSecondary,
             ),
           ),
           shape: RoundedRectangleBorder(
@@ -317,9 +318,9 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
                       ),
                       decoration: InputDecoration(
                         hintText: '예) 친구와 커피',
-                        hintStyle: const TextStyle(color: Color(0xFF666666)),
+                        hintStyle: TextStyle(color: context.colors.textSecondary),
                         filled: true,
-                        fillColor: const Color(0xFFF5F5F5),
+                        fillColor: context.colors.surface,
                         border: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(12),
                           borderSide: BorderSide.none,
@@ -424,7 +425,7 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
                         ),
                         decoration: InputDecoration(
                           hintText: '왜 생각이 바뀌었나요?',
-                          hintStyle: const TextStyle(color: Color(0xFF666666)),
+                          hintStyle: TextStyle(color: context.colors.textSecondary),
                           filled: true,
                           fillColor: const Color(0xFFFFF9E6),
                           border: OutlineInputBorder(
@@ -456,27 +457,27 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
                     const SizedBox(height: 24),
 
                     // 메모
-                    const Text(
+                    Text(
                       '메모 (선택 사항)',
                       style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.w600,
-                        color: Colors.black,
+                        color: context.colors.textSecondary,
                       ),
                     ),
                     const SizedBox(height: 12),
                     TextField(
                       controller: _memoController,
                       maxLines: 3,
-                      style: const TextStyle(
+                      style: TextStyle(
                         fontSize: 16,
-                        color: Colors.black,
+                        color: context.colors.textPrimary,
                       ),
                       decoration: InputDecoration(
                         hintText: '메모 추가...',
-                        hintStyle: const TextStyle(color: Color(0xFF666666)),
+                        hintStyle: TextStyle(color: context.colors.textSecondary),
                         filled: true,
-                        fillColor: const Color(0xFFF5F5F5),
+                        fillColor: context.colors.surface,
                         border: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(12),
                           borderSide: BorderSide.none,
@@ -512,7 +513,7 @@ class _AddExpenseScreenState extends ConsumerState<AddExpenseScreen> {
                 child: ElevatedButton(
                   onPressed: _saveExpense,
                   style: ElevatedButton.styleFrom(
-                    backgroundColor: const Color(0xFF4CAF50),
+                    backgroundColor: context.colors.primary,
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(12),
                     ),

--- a/lib/features/expense/screens/expense_list_screen.dart
+++ b/lib/features/expense/screens/expense_list_screen.dart
@@ -1,8 +1,9 @@
 import 'package:expense_tracker/core/themes/app_colors.dart';
 import 'package:expense_tracker/core/utils/layout_utils.dart';
 import 'package:expense_tracker/core/widgets/tutorial/tutorial_content_widget.dart';
-import 'package:expense_tracker/features/expense/controllers/expense_controller.dart';
 import 'package:expense_tracker/features/expense/models/expense.dart';
+import 'package:expense_tracker/features/expense/models/expense_filter.dart';
+import 'package:expense_tracker/features/expense/providers/expense_list_stream_provider.dart';
 import 'package:expense_tracker/features/expense/screens/add_expense_screen.dart';
 import 'package:expense_tracker/features/expense/screens/search_screen.dart';
 import 'package:expense_tracker/features/expense/screens/statistics_screen.dart';
@@ -31,9 +32,19 @@ class _ExpenseListScreenState extends ConsumerState<ExpenseListScreen> {
   final GlobalKey _filterKey = GlobalKey();
   final GlobalKey _expenseListKey = GlobalKey();
 
+  // 필터 상태
+  late ExpenseFilter _filter;
+
   @override
   void initState() {
     super.initState();
+    _filter = ExpenseFilter.thisMonth();
+  }
+
+  void _updateFilter(ExpenseFilter newFilter) {
+    setState(() {
+      _filter = newFilter;
+    });
   }
 
   /// 튜토리얼 모드인지 확인
@@ -120,8 +131,15 @@ class _ExpenseListScreenState extends ConsumerState<ExpenseListScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final expensesAsync = ref.watch(expenseControllerProvider);
     final tutorialState = ref.watch(tutorialControllerProvider);
+    final expensesAsync = ref.watch(expenseListStreamProvider(_filter));
+
+    // 이전 데이터 캐싱 (깜빡임 방지)
+    final cachedExpenses = expensesAsync.when(
+      data: (data) => data,
+      loading: () => expensesAsync.value ?? [],
+      error: (_, _) => expensesAsync.value ?? [],
+    );
 
     // 데이터 로딩 완료 후 튜토리얼을 본적이 없다면 튜토리얼 표시
     if (!tutorialState.hasSeenTutorial && expensesAsync.hasValue) {
@@ -179,17 +197,21 @@ class _ExpenseListScreenState extends ConsumerState<ExpenseListScreen> {
       ),
       body: Padding(
         padding: systemBarsPadding(context),
-        child: expensesAsync.when(
-          data: (state) {
-            final expenses = _getDisplayExpenses(
+        child: Builder(
+          builder: (context) {
+            final displayExpenses = _getDisplayExpenses(
               tutorialState,
-              state.filteredExpenses,
+              cachedExpenses,
             );
-            final selectedFilter = state.filter;
             final totalAmount = _getTotalAmount(
               tutorialState,
-              state.totalAmount,
+              cachedExpenses.fold<int>(
+                0,
+                (int sum, Expense e) => sum + e.amount,
+              ),
             );
+            final selectedFilter = _filter.emotion;
+
             return Column(
               children: [
                 // 필터 탭
@@ -205,41 +227,41 @@ class _ExpenseListScreenState extends ConsumerState<ExpenseListScreen> {
                           key: _filterKey,
                           label: '전체',
                           isSelected: selectedFilter == null,
-                          onTap: () => ref
-                              .read(expenseControllerProvider.notifier)
-                              .setFilter(null),
+                          onTap: () => _updateFilter(
+                            _filter.copyWith(clearEmotion: true),
+                          ),
                         ),
                         const SizedBox(width: 8),
                         FilterChipWidget(
                           label: '잘 쓴 돈',
                           isSelected: selectedFilter == ExpenseEmotions.good,
-                          onTap: () => ref
-                              .read(expenseControllerProvider.notifier)
-                              .setFilter(ExpenseEmotions.good),
+                          onTap: () => _updateFilter(
+                            _filter.copyWith(emotion: ExpenseEmotions.good),
+                          ),
                         ),
                         const SizedBox(width: 8),
                         FilterChipWidget(
                           label: '그저 그런 돈',
                           isSelected: selectedFilter == ExpenseEmotions.normal,
-                          onTap: () => ref
-                              .read(expenseControllerProvider.notifier)
-                              .setFilter(ExpenseEmotions.normal),
+                          onTap: () => _updateFilter(
+                            _filter.copyWith(emotion: ExpenseEmotions.normal),
+                          ),
                         ),
                         const SizedBox(width: 8),
                         FilterChipWidget(
                           label: '아까운 돈',
                           isSelected: selectedFilter == ExpenseEmotions.regret,
-                          onTap: () => ref
-                              .read(expenseControllerProvider.notifier)
-                              .setFilter(ExpenseEmotions.regret),
+                          onTap: () => _updateFilter(
+                            _filter.copyWith(emotion: ExpenseEmotions.regret),
+                          ),
                         ),
                         const SizedBox(width: 8),
                         FilterChipWidget(
                           label: '후회한 돈',
                           isSelected: selectedFilter == ExpenseEmotions.bad,
-                          onTap: () => ref
-                              .read(expenseControllerProvider.notifier)
-                              .setFilter(ExpenseEmotions.bad),
+                          onTap: () => _updateFilter(
+                            _filter.copyWith(emotion: ExpenseEmotions.bad),
+                          ),
                         ),
                       ],
                     ),
@@ -250,6 +272,15 @@ class _ExpenseListScreenState extends ConsumerState<ExpenseListScreen> {
                 ExpenseSummaryCard(
                   totalAmount: totalAmount,
                   selectedFilter: selectedFilter,
+                  selectedDate: _filter.startDate,
+                  onMonthChanged: (DateTime newDate) {
+                    _updateFilter(
+                      _filter.copyWith(
+                        startDate: DateTime(newDate.year, newDate.month),
+                        endDate: DateTime(newDate.year, newDate.month + 1, 0),
+                      ),
+                    );
+                  },
                 ),
 
                 const SizedBox(height: 8),
@@ -257,18 +288,18 @@ class _ExpenseListScreenState extends ConsumerState<ExpenseListScreen> {
                 // 지출 목록
                 Expanded(
                   key: _expenseListKey,
-                  child: expenses.isEmpty
+                  child: displayExpenses.isEmpty
                       ? const EmptyExpenseState()
                       : ListView.builder(
                           padding: const EdgeInsets.symmetric(horizontal: 16),
-                          itemCount: expenses.length,
+                          itemCount: displayExpenses.length,
                           itemBuilder: (context, index) {
-                            final expense = expenses[index];
+                            final expense = displayExpenses[index];
                             final showDate =
                                 index == 0 ||
                                 !_isSameDay(
                                   expense.date,
-                                  expenses[index - 1].date,
+                                  displayExpenses[index - 1].date,
                                 );
 
                             return Column(
@@ -298,8 +329,6 @@ class _ExpenseListScreenState extends ConsumerState<ExpenseListScreen> {
               ],
             );
           },
-          loading: () => const Center(child: CircularProgressIndicator()),
-          error: (error, _) => Center(child: Text('오류가 발생했습니다: $error')),
         ),
       ),
       floatingActionButton: FloatingActionButton(

--- a/lib/features/expense/screens/expense_list_screen.dart
+++ b/lib/features/expense/screens/expense_list_screen.dart
@@ -149,7 +149,7 @@ class _ExpenseListScreenState extends ConsumerState<ExpenseListScreen> {
     }
 
     return Scaffold(
-      backgroundColor: const Color(0xFFF5F5F5),
+      backgroundColor: context.colors.surface,
       appBar: AppBar(
         title: const Text(
           '지출 목록',
@@ -311,10 +311,10 @@ class _ExpenseListScreenState extends ConsumerState<ExpenseListScreen> {
                                     padding: const EdgeInsets.only(bottom: 12),
                                     child: Text(
                                       _formatDate(expense.date),
-                                      style: const TextStyle(
+                                      style: TextStyle(
                                         fontSize: 14,
                                         fontWeight: FontWeight.w600,
-                                        color: Color(0xFF4CAF50),
+                                        color: context.colors.primary,
                                       ),
                                     ),
                                   ),

--- a/lib/features/expense/widgets/expense_list/expense_summary_card.dart
+++ b/lib/features/expense/widgets/expense_list/expense_summary_card.dart
@@ -1,3 +1,4 @@
+import 'package:expense_tracker/core/themes/app_colors.dart';
 import 'package:expense_tracker/features/expense/models/expense.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -45,14 +46,14 @@ class ExpenseSummaryCard extends StatelessWidget {
                   );
                   onMonthChanged(previousMonth);
                 },
-                color: const Color(0xFF4CAF50),
+                color: context.colors.primary,
               ),
               Text(
                 DateFormat('yyyy.MM').format(selectedDate),
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 18,
                   fontWeight: FontWeight.bold,
-                  color: Colors.black,
+                  color: context.colors.textPrimary,
                 ),
               ),
               IconButton(
@@ -64,7 +65,7 @@ class ExpenseSummaryCard extends StatelessWidget {
                   );
                   onMonthChanged(nextMonth);
                 },
-                color: const Color(0xFF4CAF50),
+                color: context.colors.primary,
               ),
             ],
           ),
@@ -75,17 +76,17 @@ class ExpenseSummaryCard extends StatelessWidget {
             children: [
               Text(
                 selectedFilter == null ? '총 지출' : selectedFilter!.label,
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 16,
-                  color: Color(0xFF666666),
+                  color: context.colors.textSecondary,
                 ),
               ),
               Text(
                 '${NumberFormat('#,###').format(totalAmount)}원',
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 24,
                   fontWeight: FontWeight.bold,
-                  color: Colors.black,
+                  color: context.colors.textPrimary,
                 ),
               ),
             ],

--- a/lib/features/expense/widgets/expense_list/expense_summary_card.dart
+++ b/lib/features/expense/widgets/expense_list/expense_summary_card.dart
@@ -29,7 +29,7 @@ class ExpenseSummaryCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       color: Colors.white,
-      padding: const EdgeInsets.all(20),
+      padding: const EdgeInsets.fromLTRB(20,4,20,20),
       child: Column(
         children: [
           // 월 선택 UI

--- a/lib/features/expense/widgets/expense_list/expense_summary_card.dart
+++ b/lib/features/expense/widgets/expense_list/expense_summary_card.dart
@@ -29,7 +29,7 @@ class ExpenseSummaryCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       color: Colors.white,
-      padding: const EdgeInsets.fromLTRB(20,4,20,20),
+      padding: const EdgeInsets.fromLTRB(20, 4, 20, 20),
       child: Column(
         children: [
           // 월 선택 UI

--- a/lib/features/expense/widgets/expense_list/expense_summary_card.dart
+++ b/lib/features/expense/widgets/expense_list/expense_summary_card.dart
@@ -8,11 +8,19 @@ class ExpenseSummaryCard extends StatelessWidget {
   const ExpenseSummaryCard({
     super.key,
     required this.totalAmount,
+    required this.selectedDate,
+    required this.onMonthChanged,
     this.selectedFilter,
   });
 
   /// 총 금액
   final int totalAmount;
+
+  /// 선택된 날짜 (월 표시용)
+  final DateTime selectedDate;
+
+  /// 월 변경 콜백
+  final Function(DateTime) onMonthChanged;
 
   /// 선택된 필터
   final ExpenseEmotions? selectedFilter;
@@ -22,23 +30,65 @@ class ExpenseSummaryCard extends StatelessWidget {
     return Container(
       color: Colors.white,
       padding: const EdgeInsets.all(20),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      child: Column(
         children: [
-          Text(
-            selectedFilter == null ? '총 지출' : selectedFilter!.label,
-            style: const TextStyle(
-              fontSize: 16,
-              color: Color(0xFF666666),
-            ),
+          // 월 선택 UI
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              IconButton(
+                icon: const Icon(Icons.chevron_left),
+                onPressed: () {
+                  final previousMonth = DateTime(
+                    selectedDate.year,
+                    selectedDate.month - 1,
+                  );
+                  onMonthChanged(previousMonth);
+                },
+                color: const Color(0xFF4CAF50),
+              ),
+              Text(
+                DateFormat('yyyy.MM').format(selectedDate),
+                style: const TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.black,
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.chevron_right),
+                onPressed: () {
+                  final nextMonth = DateTime(
+                    selectedDate.year,
+                    selectedDate.month + 1,
+                  );
+                  onMonthChanged(nextMonth);
+                },
+                color: const Color(0xFF4CAF50),
+              ),
+            ],
           ),
-          Text(
-            '${NumberFormat('#,###').format(totalAmount)}원',
-            style: const TextStyle(
-              fontSize: 24,
-              fontWeight: FontWeight.bold,
-              color: Colors.black,
-            ),
+          const SizedBox(height: 12),
+          // 총 금액
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                selectedFilter == null ? '총 지출' : selectedFilter!.label,
+                style: const TextStyle(
+                  fontSize: 16,
+                  color: Color(0xFF666666),
+                ),
+              ),
+              Text(
+                '${NumberFormat('#,###').format(totalAmount)}원',
+                style: const TextStyle(
+                  fontSize: 24,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.black,
+                ),
+              ),
+            ],
           ),
         ],
       ),

--- a/test/core/dao/expense_dao_test.dart
+++ b/test/core/dao/expense_dao_test.dart
@@ -190,5 +190,464 @@ void main() {
       expect(regret.first.emotion, 'regret');
       expect(regret.first.title, '아까운 커피');
     });
+
+    group('watchExpenses - 감정 필터링', () {
+      test('감정 필터가 null이면 모든 감정 데이터 반환', () async {
+        // Given: 다양한 감정의 데이터 추가
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '좋은 점심',
+            amount: 10000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.good.name,
+            date: DateTime(2024, 1, 15),
+          ),
+        );
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '아까운 커피',
+            amount: 5000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.regret.name,
+            date: DateTime(2024, 1, 16),
+          ),
+        );
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '후회한 택시',
+            amount: 20000,
+            category: ExpenseCategory.transport.name,
+            emotion: ExpenseEmotions.bad.name,
+            date: DateTime(2024, 1, 17),
+          ),
+        );
+
+        // When: 감정 필터 없이 조회
+        final stream = dao.watchExpenses(
+          startDate: DateTime(2024),
+          endDate: DateTime(2024, 1, 31),
+        );
+
+        // Then: 모든 데이터 반환
+        final result = await stream.first;
+        expect(result.length, 3);
+      });
+
+      test('특정 감정으로 필터링하면 해당 감정만 반환', () async {
+        // Given: 다양한 감정의 데이터 추가
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '좋은 점심',
+            amount: 10000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.good.name,
+            date: DateTime(2024, 1, 15),
+          ),
+        );
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '좋은 저녁',
+            amount: 15000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.good.name,
+            date: DateTime(2024, 1, 16),
+          ),
+        );
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '아까운 커피',
+            amount: 5000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.regret.name,
+            date: DateTime(2024, 1, 17),
+          ),
+        );
+
+        // When: 'good' 감정으로 필터링
+        final stream = dao.watchExpenses(
+          emotion: ExpenseEmotions.good.name,
+          startDate: DateTime(2024),
+          endDate: DateTime(2024, 1, 31),
+        );
+
+        // Then: 'good' 감정만 반환
+        final result = await stream.first;
+        expect(result.length, 2);
+        expect(result.every((e) => e.emotion == 'good'), isTrue);
+        expect(result.map((e) => e.title).toList(), ['좋은 저녁', '좋은 점심']);
+      });
+    });
+
+    group('watchExpenses - 날짜 필터링', () {
+      test('1월 전체 조회 시 1월 31일 데이터까지 포함', () async {
+        // Given: 1월 1일부터 2월 1일까지 데이터 추가
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '1월 1일',
+            amount: 10000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.good.name,
+            date: DateTime(2024),
+          ),
+        );
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '1월 15일',
+            amount: 15000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.good.name,
+            date: DateTime(2024, 1, 15),
+          ),
+        );
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '1월 31일',
+            amount: 20000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.good.name,
+            date: DateTime(2024, 1, 31),
+          ),
+        );
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '2월 1일',
+            amount: 25000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.good.name,
+            date: DateTime(2024, 2),
+          ),
+        );
+
+        // When: 1월 전체 조회
+        final stream = dao.watchExpenses(
+          startDate: DateTime(2024),
+          endDate: DateTime(2024, 1, 31),
+        );
+
+        // Then: 1월 데이터만 반환 (1일, 15일, 31일)
+        final result = await stream.first;
+        expect(result.length, 3);
+        expect(result.map((e) => e.title).toList(), [
+          '1월 31일',
+          '1월 15일',
+          '1월 1일',
+        ]);
+      });
+
+      test('1월 31일 23:59:59 데이터도 포함', () async {
+        // Given: 1월 31일 다양한 시간대 데이터 추가
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '1월 31일 00:00',
+            amount: 10000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.good.name,
+            date: DateTime(2024, 1, 31),
+          ),
+        );
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '1월 31일 23:59',
+            amount: 15000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.good.name,
+            date: DateTime(2024, 1, 31, 23, 59, 59),
+          ),
+        );
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '2월 1일 00:00',
+            amount: 20000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.good.name,
+            date: DateTime(2024, 2),
+          ),
+        );
+
+        // When: 1월 전체 조회
+        final stream = dao.watchExpenses(
+          startDate: DateTime(2024),
+          endDate: DateTime(2024, 1, 31),
+        );
+
+        // Then: 1월 31일 23:59:59까지 포함, 2월 1일은 제외
+        final result = await stream.first;
+        expect(result.length, 2);
+        expect(result.map((e) => e.title).toList(), [
+          '1월 31일 23:59',
+          '1월 31일 00:00',
+        ]);
+      });
+
+      test('날짜 범위 밖의 데이터는 제외', () async {
+        // Given: 다양한 월의 데이터 추가
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '12월 데이터',
+            amount: 10000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.good.name,
+            date: DateTime(2023, 12, 31),
+          ),
+        );
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '1월 데이터',
+            amount: 15000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.good.name,
+            date: DateTime(2024, 1, 15),
+          ),
+        );
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '2월 데이터',
+            amount: 20000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.good.name,
+            date: DateTime(2024, 2),
+          ),
+        );
+
+        // When: 1월만 조회
+        final stream = dao.watchExpenses(
+          startDate: DateTime(2024),
+          endDate: DateTime(2024, 1, 31),
+        );
+
+        // Then: 1월 데이터만 반환
+        final result = await stream.first;
+        expect(result.length, 1);
+        expect(result.first.title, '1월 데이터');
+      });
+    });
+
+    group('watchExpenses - Stream 반응성', () {
+      test('데이터 추가 시 Stream이 자동으로 갱신', () async {
+        // Given: 초기 데이터 1개
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '초기 데이터',
+            amount: 10000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.good.name,
+            date: DateTime(2024, 1, 15),
+          ),
+        );
+
+        final stream = dao.watchExpenses(
+          startDate: DateTime(2024),
+          endDate: DateTime(2024, 1, 31),
+        );
+
+        // When: Stream 구독 후 데이터 추가
+        final emissions = <List<ExpenseEntityData>>[];
+        final subscription = stream.listen(emissions.add);
+
+        // 첫 번째 emit 대기
+        await Future.delayed(const Duration(milliseconds: 100));
+
+        // 새 데이터 추가
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '추가 데이터',
+            amount: 15000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.good.name,
+            date: DateTime(2024, 1, 16),
+          ),
+        );
+
+        // Stream 갱신 대기
+        await Future.delayed(const Duration(milliseconds: 100));
+
+        // Then: Stream이 2번 emit (초기 1개 → 추가 후 2개)
+        expect(emissions.length, greaterThanOrEqualTo(2));
+        expect(emissions.first.length, 1);
+        expect(emissions.last.length, 2);
+
+        await subscription.cancel();
+      });
+
+      test('데이터 삭제 시 Stream이 자동으로 갱신', () async {
+        // Given: 초기 데이터 2개
+        final id1 = await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '데이터 1',
+            amount: 10000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.good.name,
+            date: DateTime(2024, 1, 15),
+          ),
+        );
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '데이터 2',
+            amount: 15000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.good.name,
+            date: DateTime(2024, 1, 16),
+          ),
+        );
+
+        final stream = dao.watchExpenses(
+          startDate: DateTime(2024),
+          endDate: DateTime(2024, 1, 31),
+        );
+
+        // When: Stream 구독 후 데이터 삭제
+        final emissions = <List<ExpenseEntityData>>[];
+        final subscription = stream.listen(emissions.add);
+
+        await Future.delayed(const Duration(milliseconds: 100));
+
+        // 데이터 삭제
+        await dao.deleteExpense(id1);
+
+        await Future.delayed(const Duration(milliseconds: 100));
+
+        // Then: Stream이 2번 emit (초기 2개 → 삭제 후 1개)
+        expect(emissions.length, greaterThanOrEqualTo(2));
+        expect(emissions.first.length, 2);
+        expect(emissions.last.length, 1);
+        expect(emissions.last.first.title, '데이터 2');
+
+        await subscription.cancel();
+      });
+
+      test('데이터 수정 시 Stream이 자동으로 갱신', () async {
+        // Given: 초기 데이터 1개
+        final id = await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '원본 데이터',
+            amount: 10000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.good.name,
+            date: DateTime(2024, 1, 15),
+          ),
+        );
+
+        final stream = dao.watchExpenses(
+          startDate: DateTime(2024),
+          endDate: DateTime(2024, 1, 31),
+        );
+
+        // When: Stream 구독 후 데이터 수정
+        final emissions = <List<ExpenseEntityData>>[];
+        final subscription = stream.listen(emissions.add);
+
+        await Future.delayed(const Duration(milliseconds: 100));
+
+        // 데이터 수정
+        await dao.updateExpense(
+          ExpenseEntityCompanion(
+            id: Value(id),
+            title: const Value('수정된 데이터'),
+            amount: const Value(20000),
+            category: Value(ExpenseCategory.food.name),
+            emotion: Value(ExpenseEmotions.regret.name),
+            date: Value(DateTime(2024, 1, 15)),
+          ),
+        );
+
+        await Future.delayed(const Duration(milliseconds: 100));
+
+        // Then: Stream이 갱신되고 수정된 데이터 반환
+        expect(emissions.length, greaterThanOrEqualTo(2));
+        expect(emissions.last.first.title, '수정된 데이터');
+        expect(emissions.last.first.amount, 20000);
+        expect(emissions.last.first.emotion, 'regret');
+
+        await subscription.cancel();
+      });
+
+      test('필터 범위 밖 데이터 추가 시 Stream에 영향 없음', () async {
+        // Given: 1월 데이터 1개
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '1월 데이터',
+            amount: 10000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.good.name,
+            date: DateTime(2024, 1, 15),
+          ),
+        );
+
+        final stream = dao.watchExpenses(
+          startDate: DateTime(2024),
+          endDate: DateTime(2024, 1, 31),
+        );
+
+        // When: Stream 구독 후 2월 데이터 추가
+        final emissions = <List<ExpenseEntityData>>[];
+        final subscription = stream.listen(emissions.add);
+
+        await Future.delayed(const Duration(milliseconds: 100));
+
+        // 2월 데이터 추가 (필터 범위 밖)
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '2월 데이터',
+            amount: 15000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.good.name,
+            date: DateTime(2024, 2),
+          ),
+        );
+
+        await Future.delayed(const Duration(milliseconds: 100));
+
+        // Then: 1월 필터에는 여전히 1개만 표시
+        expect(emissions.last.length, 1);
+        expect(emissions.last.first.title, '1월 데이터');
+
+        await subscription.cancel();
+      });
+    });
+
+    group('watchExpenses - 복합 필터링', () {
+      test('감정 + 날짜 필터 동시 적용', () async {
+        // Given: 다양한 감정과 날짜의 데이터
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '1월 good',
+            amount: 10000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.good.name,
+            date: DateTime(2024, 1, 15),
+          ),
+        );
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '1월 regret',
+            amount: 15000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.regret.name,
+            date: DateTime(2024, 1, 16),
+          ),
+        );
+        await dao.addExpense(
+          ExpenseEntityCompanion.insert(
+            title: '2월 good',
+            amount: 20000,
+            category: ExpenseCategory.food.name,
+            emotion: ExpenseEmotions.good.name,
+            date: DateTime(2024, 2),
+          ),
+        );
+
+        // When: 1월 + good 필터
+        final stream = dao.watchExpenses(
+          emotion: ExpenseEmotions.good.name,
+          startDate: DateTime(2024),
+          endDate: DateTime(2024, 1, 31),
+        );
+
+        // Then: 1월의 good만 반환
+        final result = await stream.first;
+        expect(result.length, 1);
+        expect(result.first.title, '1월 good');
+      });
+    });
   });
 }

--- a/test/mocks/mock_expense_repository.dart
+++ b/test/mocks/mock_expense_repository.dart
@@ -102,7 +102,9 @@ class MockExpenseRepository implements ExpenseRepository {
               expenseFilter.endDate.add(const Duration(days: 1)),
             );
 
-        if (!isInDateRange) return false;
+        if (!isInDateRange) {
+          return false;
+        }
 
         // 감정 필터링
         if (expenseFilter.emotion != null) {

--- a/test/mocks/mock_expense_repository.dart
+++ b/test/mocks/mock_expense_repository.dart
@@ -1,10 +1,14 @@
+import 'dart:async';
+
 import 'package:expense_tracker/features/expense/models/expense.dart';
+import 'package:expense_tracker/features/expense/models/expense_filter.dart';
 import 'package:expense_tracker/features/expense/models/expense_form.dart';
 import 'package:expense_tracker/features/expense/repositories/expense_repository.dart';
 
 /// Mock ExpenseService for testing
 class MockExpenseRepository implements ExpenseRepository {
   final List<Expense> _expenses = [];
+  final _controller = StreamController<List<Expense>>.broadcast();
 
   @override
   Future<List<Expense>> getAllExpenses() async {
@@ -24,6 +28,7 @@ class MockExpenseRepository implements ExpenseRepository {
       createdAt: DateTime.now(),
     );
     _expenses.add(expense);
+    _notifyListeners();
     return expense.id;
   }
 
@@ -41,12 +46,14 @@ class MockExpenseRepository implements ExpenseRepository {
     final index = _expenses.indexWhere((e) => e.id == expense.id);
     if (index != -1) {
       _expenses[index] = expense;
+      _notifyListeners();
     }
   }
 
   @override
   Future<void> deleteExpense(int id) async {
     _expenses.removeWhere((e) => e.id == id);
+    _notifyListeners();
   }
 
   @override
@@ -74,5 +81,45 @@ class MockExpenseRepository implements ExpenseRepository {
   Future<List<Expense>> filterByStatus(ExpenseEmotions emotion) async {
     return _expenses.where((expense) => expense.emotion == emotion).toList()
       ..sort((a, b) => b.date.compareTo(a.date));
+  }
+
+  @override
+  Stream<List<Expense>> watchExpenses({
+    required ExpenseFilter expenseFilter,
+  }) {
+    // 초기 데이터 emit
+    _notifyListeners();
+
+    // Stream 변환: 필터링 적용
+    return _controller.stream.map((expenses) {
+      return expenses.where((expense) {
+        // 날짜 필터링
+        final isInDateRange =
+            expense.date.isAfter(
+              expenseFilter.startDate.subtract(const Duration(seconds: 1)),
+            ) &&
+            expense.date.isBefore(
+              expenseFilter.endDate.add(const Duration(days: 1)),
+            );
+
+        if (!isInDateRange) return false;
+
+        // 감정 필터링
+        if (expenseFilter.emotion != null) {
+          return expense.emotion == expenseFilter.emotion;
+        }
+
+        return true;
+      }).toList()..sort((a, b) => b.date.compareTo(a.date));
+    });
+  }
+
+  void _notifyListeners() {
+    _controller.add(List.from(_expenses));
+  }
+
+  /// 테스트 종료 시 호출
+  void dispose() {
+    _controller.close();
   }
 }


### PR DESCRIPTION
지출 리스트 화면에 날짜 필터가 나온다

추후에 해야할 작업
지출 추가/삭제/수정을 위한 Controller 작성
통계 화면에서도 날짜 필터가 나온다, 하지만 여기서는 연,월, 일 기준으로 필터링 가능하도록 설정 (보다 촘촘한 필터)
검색 최적화

This closes #50 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 월별 네비게이션(이전/다음 월)과 선택된 월 기반 요약 추가
  * 기간·감정 기준의 실시간(스트림) 지출 조회 및 관련 필터 모델·공급자 추가

* **개선**
  * 화면을 스트림 기반 데이터 소스로 전환해 UI 응답성·상태 일관성 향상
  * 저장/수정/삭제를 비동기로 처리하고 안전한 네비게이션 및 테마 색상 적용

* **테스트**
  * 기간·감정 필터와 스트리밍 반응성을 검증하는 포괄적 테스트 추가

* **기타**
  * 테스트용 모의 저장소에 실시간 스트림 지원 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->