### PR TITLE
feat: 릴리즈 브랜치 검증용 ci, 릴리즈노트도 패스트레인에 실어서 보내도록 설정

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -19,6 +19,11 @@ jobs:
       - name: 버전 변경 확인
         run: |
           CURRENT_VERSION=$(grep "^version:" pubspec.yaml | sed 's/version: //')
+          if ! echo "$CURRENT_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+\+[0-9]+$'; then
+            echo "❌ pubspec.yaml version 형식 오류: $CURRENT_VERSION"
+            echo "   - 기대 형식: major.minor.patch+buildNumber (예: 0.2.0+5)"
+            exit 1
+          fi
           CURRENT_VERSION_NAME=$(echo $CURRENT_VERSION | cut -d'+' -f1)
           CURRENT_VERSION_CODE=$(echo $CURRENT_VERSION | cut -d'+' -f2)
 

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,83 @@
+name: 버전 변경 검증
+
+on:
+  push:
+    branches:
+      - "release/**"
+
+jobs:
+  version-check:
+    name: 버전 코드/네임 변경 검증
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 리포지토리 체크아웃
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: 버전 변경 확인
+        run: |
+          CURRENT_VERSION=$(grep "^version:" pubspec.yaml | sed 's/version: //')
+          CURRENT_VERSION_NAME=$(echo $CURRENT_VERSION | cut -d'+' -f1)
+          CURRENT_VERSION_CODE=$(echo $CURRENT_VERSION | cut -d'+' -f2)
+
+          git fetch origin main
+          git checkout origin/main -- pubspec.yaml 2>/dev/null || exit 0
+
+          MAIN_VERSION=$(grep "^version:" pubspec.yaml | sed 's/version: //')
+          MAIN_VERSION_NAME=$(echo $MAIN_VERSION | cut -d'+' -f1)
+          MAIN_VERSION_CODE=$(echo $MAIN_VERSION | cut -d'+' -f2)
+
+          git checkout HEAD -- pubspec.yaml
+
+          if [ "$CURRENT_VERSION_NAME" = "$MAIN_VERSION_NAME" ]; then
+            echo "❌ 버전 네임이 main 브랜치와 동일합니다: $MAIN_VERSION_NAME"
+            exit 1
+          fi
+
+          if [ "$CURRENT_VERSION_CODE" = "$MAIN_VERSION_CODE" ]; then
+            echo "❌ 버전 코드가 main 브랜치와 동일합니다: $MAIN_VERSION_CODE"
+            exit 1
+          fi
+
+      - name: 릴리즈 노트 존재 확인
+        run: |
+          CURRENT_VERSION=$(grep "^version:" pubspec.yaml | sed 's/version: //')
+          VERSION_NAME=$(echo $CURRENT_VERSION | cut -d'+' -f1)
+          RELEASE_NOTE_PATH="docs/releaseNotes/${VERSION_NAME}.md"
+
+          if [ ! -f "$RELEASE_NOTE_PATH" ]; then
+            echo "❌ 릴리즈 노트 파일이 존재하지 않습니다: $RELEASE_NOTE_PATH"
+            exit 1
+          fi
+
+          if [ ! -s "$RELEASE_NOTE_PATH" ]; then
+            echo "❌ 릴리즈 노트 파일이 비어있습니다: $RELEASE_NOTE_PATH"
+            exit 1
+          fi
+
+      - name: 검증 결과 요약
+        if: success()
+        run: |
+          CURRENT_VERSION=$(grep "^version:" pubspec.yaml | sed 's/version: //')
+          VERSION_NAME=$(echo $CURRENT_VERSION | cut -d'+' -f1)
+
+          echo "## ✅ 버전 검증 통과" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ pubspec.yaml 버전 네임/코드 변경" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ 릴리즈 노트: \`docs/releaseNotes/${VERSION_NAME}.md\`" >> $GITHUB_STEP_SUMMARY
+
+      - name: 검증 실패 알림
+        if: failure()
+        run: |
+          CURRENT_VERSION=$(grep "^version:" pubspec.yaml | sed 's/version: //')
+          VERSION_NAME=$(echo $CURRENT_VERSION | cut -d'+' -f1)
+
+          echo "## ❌ 버전 검증 실패" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### 필수 확인 사항" >> $GITHUB_STEP_SUMMARY
+          echo "1. **pubspec.yaml**: 버전 네임과 버전 코드 둘 다 변경 필요" >> $GITHUB_STEP_SUMMARY
+          echo "   - 형식: \`major.minor.patch+buildNumber\` (예: 0.2.0+5)" >> $GITHUB_STEP_SUMMARY
+          echo "2. **릴리즈 노트**: \`docs/releaseNotes/${VERSION_NAME}.md\`" >> $GITHUB_STEP_SUMMARY
+          exit 1

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -20,15 +20,18 @@ jobs:
         run: |
           CURRENT_VERSION=$(grep "^version:" pubspec.yaml | sed 's/version: //')
           if ! echo "$CURRENT_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+\+[0-9]+$'; then
-            echo "❌ pubspec.yaml version 형식 오류: $CURRENT_VERSION"
-            echo "   - 기대 형식: major.minor.patch+buildNumber (예: 0.2.0+5)"
-            exit 1
+           echo "❌ pubspec.yaml version 형식 오류: $CURRENT_VERSION"
+           echo "   - 기대 형식: major.minor.patch+buildNumber (예: 0.2.0+5)"
+           exit 1
           fi
           CURRENT_VERSION_NAME=$(echo $CURRENT_VERSION | cut -d'+' -f1)
           CURRENT_VERSION_CODE=$(echo $CURRENT_VERSION | cut -d'+' -f2)
 
           git fetch origin main
-          git checkout origin/main -- pubspec.yaml 2>/dev/null || exit 0
+          git checkout origin/main -- pubspec.yaml 2>/dev/null || {
+            echo "❌ origin/main의 pubspec.yaml을 가져오지 못했습니다."
+            exit 1
+          }
 
           MAIN_VERSION=$(grep "^version:" pubspec.yaml | sed 's/version: //')
           MAIN_VERSION_NAME=$(echo $MAIN_VERSION | cut -d'+' -f1)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,9 +2,27 @@ default_platform(:ios)
 
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 
+def load_version_and_changelog
+  pubspec_content = File.read("../pubspec.yaml")
+  version = pubspec_content.match(/version:\s*(.+)/)[1].strip
+  version_name = version.split('+')[0]
+  
+  release_note_path = "../docs/releaseNotes/#{version_name}.md"
+  if File.exist?(release_note_path)
+    changelog = File.read(release_note_path)
+    UI.message("릴리즈 노트 로드: #{release_note_path}")
+  else
+    UI.user_error!("릴리즈 노트를 찾을 수 없습니다: #{release_note_path}")
+  end
+  
+  return version_name, changelog
+end
+
 platform :ios do
   desc "TestFlight에 업로드"
   lane :beta do
+    version_name, changelog = load_version_and_changelog
+    
     # App Store Connect API 인증
     api_key = app_store_connect_api_key(
       key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
@@ -43,13 +61,18 @@ platform :ios do
     )
 
     # TestFlight 업로드
-    upload_to_testflight(api_key: api_key)
+    upload_to_testflight(
+      api_key: api_key,
+      changelog: changelog
+    )
   end
 end
 
 platform :android do
   desc "Google Play Store에 업로드"
   lane :deploy do
+    version_name, changelog = load_version_and_changelog
+    
     # Google Play Store에 업로드 (internal 트랙)
     # AAB 파일은 워크플로우에서 이미 빌드됨
     upload_to_play_store(
@@ -59,7 +82,11 @@ platform :android do
       json_key_data: ENV["PLAY_STORE_CONFIG_JSON"],
       skip_upload_screenshots: true,
       skip_upload_images: true,
-      skip_upload_metadata: true,
+      skip_upload_metadata: false,
+      version_name: version_name,
+      release_notes: {
+        "ko-KR" => changelog
+      }
     )
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -4,12 +4,15 @@ ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 
 def load_version_and_changelog
   pubspec_content = File.read("../pubspec.yaml")
-  version = pubspec_content.match(/version:\s*(.+)/)[1].strip
-  version_name = version.split('+')[0]
+  version_match = pubspec_content.match(/^\s*version:\s*([^\s#]+)/)
+  UI.user_error!("pubspec.yaml에서 version 값을 찾을 수 없습니다.") unless version_match
+  version = version_match[1].strip
+  version_name = version.split('+', 2).first
   
   release_note_path = "../docs/releaseNotes/#{version_name}.md"
   if File.exist?(release_note_path)
-    changelog = File.read(release_note_path)
+    changelog = File.read(release_note_path).strip
+    UI.user_error!("릴리즈 노트가 비어 있습니다: #{release_note_path}") if changelog.empty?
     UI.message("릴리즈 노트 로드: #{release_note_path}")
   else
     UI.user_error!("릴리즈 노트를 찾을 수 없습니다: #{release_note_path}")


### PR DESCRIPTION
메인 브랜치와 비교해서 버전네임, 코드, 릴리즈노트 비교

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


https://app.asana.com/1/1214975524872214/project/1215032327314220/task/1215032327314229?focus=true

## 릴리스 노트

* **Chores**
  * 배포 브랜치에 대한 버전 형식 및 버전 코드 검증을 CI에서 자동화하여, 메인과 중복된 버전 사용을 차단합니다.
  * 릴리스 노트 존재 및 비어있지 않음을 확인하는 검증을 추가했습니다.
  * iOS(테스트플라이트) 및 Android(플레이 스토어) 배포 흐름에 릴리스 노트를 자동으로 로드·포함하도록 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->